### PR TITLE
Display loading bar when component is still loading

### DIFF
--- a/client/kds-client/package-lock.json
+++ b/client/kds-client/package-lock.json
@@ -22,6 +22,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "bootstrap": "^5.3.2",
+        "primeng": "^16.5.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.0"
@@ -9681,6 +9682,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/primeng": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-16.5.0.tgz",
+      "integrity": "sha512-fgtTJZ76YODexoZctqCEg0on4BG4uCcJy1l4iaCoaHhMFzcgP89U4gdQ5debz0oEF4TekmBLLKvfEzGtF5fEgg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.2.0",
+        "@angular/core": "^16.2.0",
+        "@angular/forms": "^16.2.0",
+        "rxjs": "^6.0.0 || ^7.8.1",
+        "zone.js": "~0.13.0"
       }
     },
     "node_modules/proc-log": {

--- a/client/kds-client/package.json
+++ b/client/kds-client/package.json
@@ -24,6 +24,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "bootstrap": "^5.3.2",
+    "primeng": "^16.5.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/client/kds-client/src/app/app.component.html
+++ b/client/kds-client/src/app/app.component.html
@@ -17,6 +17,11 @@
               <app-order-info></app-order-info>
             </div>
           </div>
+          <p-progressBar
+            *ngIf="loading"
+            mode="indeterminate"
+            [style]="{ height: '2px' }"
+          ></p-progressBar>
         </div>
       </div>
     </div>

--- a/client/kds-client/src/app/app.component.ts
+++ b/client/kds-client/src/app/app.component.ts
@@ -1,6 +1,13 @@
 import { Component, ViewChild } from '@angular/core';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { SidebarComponent } from './components/shared/sidebar/sidebar.component';
+import {
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Router,
+} from '@angular/router';
 
 @Component({
   selector: 'app-root',
@@ -10,8 +17,32 @@ import { SidebarComponent } from './components/shared/sidebar/sidebar.component'
 export class AppComponent {
   @ViewChild(SidebarComponent) child!: SidebarComponent;
 
+  public loading: boolean = true;
   public barsIcon = faBars;
   public title = 'kds-client';
+
+  constructor(private router: Router) {
+    this.router.events.subscribe((event) => {
+      switch (event.constructor) {
+        case NavigationStart: {
+          this.loading = true;
+          break;
+        }
+        case NavigationEnd: {
+          this.loading = false;
+          break;
+        }
+        case NavigationCancel:
+        case NavigationError: {
+          this.loading = false;
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+  }
 
   public showSidebar() {
     this.child.showSidebar();

--- a/client/kds-client/src/app/app.module.ts
+++ b/client/kds-client/src/app/app.module.ts
@@ -13,6 +13,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UserInfoComponent } from './components/shared/sidebar/user-info/user-info.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
+import { ProgressBarModule } from 'primeng/progressbar';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -29,6 +31,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
     AppRoutingModule,
     BrowserAnimationsModule,
     FontAwesomeModule,
+    ProgressBarModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/client/kds-client/src/styles.css
+++ b/client/kds-client/src/styles.css
@@ -1,4 +1,6 @@
 @import "~bootstrap/dist/css/bootstrap.min.css";
+@import "primeng/resources/themes/lara-light-blue/theme.css";
+@import "primeng/resources/primeng.css";
 
 :root {
   --preparando-color: #1b4478;


### PR DESCRIPTION
It's related to #35.

Some components fetch data first before loading on the routes, so the AppComponent subscribes to the routes events and whenever there is a NavigationStart event, the loading bar will be shown, until there is a  NavigationEnd event.