### PR TITLE
Implement pagination on OrderController

### DIFF
--- a/server/kdsAPI/src/main/java/com/kdsAPI/controllers/OrderController.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/controllers/OrderController.java
@@ -11,12 +11,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kdsAPI.dto.order.OrderDTO;
 import com.kdsAPI.models.FoodOrder;
 import com.kdsAPI.repositories.OrderRepository;
 import com.kdsAPI.responses.ControllerResponse;
+import com.kdsAPI.responses.PaginatedContentResponse;
 import com.kdsAPI.responses.Response;
 import com.kdsAPI.services.AbstractService;
 import com.kdsAPI.services.state.FoodOrderCompleteStateService;
@@ -33,19 +35,24 @@ public class OrderController {
 
     private final AbstractService<FoodOrder, OrderDTO> storeOrderService;
     private final ControllerResponse<FoodOrder> response;
+    private final PaginatedContentResponse<List<FoodOrder>> paginatedContentResponse;
     private FoodOrderState foodOrderState;
-
+    private final Integer DEFAULT_PAGE_SIZE = 12;
 
     @GetMapping
-    public List<FoodOrder> getOrders() {
+    public PaginatedContentResponse<List<FoodOrder>> getOrders(@RequestParam(required = false, defaultValue = "0") Integer pageNumber) {
         foodOrderState = new FoodOrderWaitingStateService((OrderRepository)storeOrderService.getRepository());
-        return foodOrderState.getAll();
+        paginatedContentResponse.setContent(foodOrderState.getAll(pageNumber, DEFAULT_PAGE_SIZE));
+        paginatedContentResponse.setPagination(foodOrderState.getPaginationResponse(pageNumber));
+        return paginatedContentResponse;
     }
 
     @GetMapping("/archive")
-    public List<FoodOrder> getCompleteOrders() {
+    public PaginatedContentResponse<List<FoodOrder>> getCompleteOrders(@RequestParam(required = false, defaultValue = "0") Integer pageNumber) {
         foodOrderState = new FoodOrderCompleteStateService((OrderRepository)storeOrderService.getRepository());
-        return foodOrderState.getAll();
+        paginatedContentResponse.setContent(foodOrderState.getAll(pageNumber, DEFAULT_PAGE_SIZE));
+        paginatedContentResponse.setPagination(foodOrderState.getPaginationResponse(pageNumber));
+        return paginatedContentResponse;
     }
 
     @GetMapping("/{id}")

--- a/server/kdsAPI/src/main/java/com/kdsAPI/repositories/OrderRepository.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/repositories/OrderRepository.java
@@ -1,7 +1,8 @@
 package com.kdsAPI.repositories;
 
-import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,8 +11,8 @@ import com.kdsAPI.order.OrderStatus;
 
 public interface OrderRepository extends JpaRepository<FoodOrder, Long>{
    @Query("SELECT foodOrder from FoodOrder foodOrder WHERE foodOrder.foodOrderStatus != OrderStatus.COMPLETE ORDER BY foodOrder.id ASC")
-    public List<FoodOrder> findAll();
+    public Page<FoodOrder> findAll(Pageable pageable);
 
-    public List<FoodOrder> findByFoodOrderStatus(OrderStatus foodOrderStatus);
+    public Page<FoodOrder> findByFoodOrderStatus(OrderStatus foodOrderStatus, Pageable pageable);
 
 }

--- a/server/kdsAPI/src/main/java/com/kdsAPI/responses/PaginatedContentResponse.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/responses/PaginatedContentResponse.java
@@ -1,6 +1,8 @@
 package com.kdsAPI.responses;
 
 
+import org.springframework.stereotype.Component;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,8 +16,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class Response<T> {
-    private int status;
-    private String error;
-    private T data;
+@Component
+public class PaginatedContentResponse<T> {
+    private T content;
+    private PaginationResponse pagination;
 }

--- a/server/kdsAPI/src/main/java/com/kdsAPI/responses/PaginationResponse.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/responses/PaginationResponse.java
@@ -1,6 +1,5 @@
 package com.kdsAPI.responses;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,8 +13,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class Response<T> {
-    private int status;
-    private String error;
-    private T data;
+public class PaginationResponse {
+    private Long totalRecords;
+    private Integer totalPages;
+    private Integer currentPage;    
 }

--- a/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderCompleteStateService.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderCompleteStateService.java
@@ -3,19 +3,29 @@ package com.kdsAPI.services.state;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import com.kdsAPI.models.FoodOrder;
 import com.kdsAPI.order.OrderStatus;
 import com.kdsAPI.repositories.OrderRepository;
 
 public class FoodOrderCompleteStateService extends FoodOrderState {
 
+
     public FoodOrderCompleteStateService(OrderRepository repository) {
         super(repository);
     }
 
     @Override
-    public List<FoodOrder> getAll() {
-        return this.repository.findByFoodOrderStatus(OrderStatus.COMPLETE);
+    public List<FoodOrder> getAll(Integer pageNumber, Integer pageSize) {
+        setFoodOrderPage(pageNumber, pageSize);
+        return this.foodOrderPage.getContent();
+    }
+
+    private void setFoodOrderPage(Integer pageNumber, Integer pageSize) {
+        Pageable paging = PageRequest.of(pageNumber, pageSize);
+        this.foodOrderPage = this.repository.findByFoodOrderStatus(OrderStatus.COMPLETE, paging);
     }
 
 }

--- a/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderState.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderState.java
@@ -2,17 +2,26 @@ package com.kdsAPI.services.state;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import com.kdsAPI.models.FoodOrder;
 import com.kdsAPI.repositories.OrderRepository;
+import com.kdsAPI.responses.PaginationResponse;
 
 public abstract class FoodOrderState {
 
     protected OrderRepository repository;
+    protected Page<FoodOrder> foodOrderPage;
 
     public FoodOrderState(OrderRepository repository) {
         this.repository = repository;
     }
 
-    public abstract List<FoodOrder> getAll();
+    public abstract List<FoodOrder> getAll(Integer pageNumber, Integer pageSize);
+
+    public PaginationResponse getPaginationResponse(Integer currentPage) {
+        return this.foodOrderPage != null ? new PaginationResponse(this.foodOrderPage.getTotalElements(), this.foodOrderPage.getTotalPages(), currentPage)
+        : null;
+    }
 
 }

--- a/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderWaitingStateService.java
+++ b/server/kdsAPI/src/main/java/com/kdsAPI/services/state/FoodOrderWaitingStateService.java
@@ -2,6 +2,9 @@ package com.kdsAPI.services.state;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import com.kdsAPI.models.FoodOrder;
 import com.kdsAPI.repositories.OrderRepository;
 
@@ -12,7 +15,13 @@ public class FoodOrderWaitingStateService extends FoodOrderState {
     }
 
     @Override
-    public List<FoodOrder> getAll() {
-        return this.repository.findAll();
+    public List<FoodOrder> getAll(Integer pageNumber, Integer pageSize) {
+        setFoodOrderPage(pageNumber, pageSize);
+        return this.foodOrderPage.getContent();
+    }
+
+    private void setFoodOrderPage(Integer pageNumber, Integer pageSize) {
+        Pageable paging = PageRequest.of(pageNumber, pageSize);
+        this.foodOrderPage = this.repository.findAll(paging);
     }
 }


### PR DESCRIPTION
This closes #33.

Both the /orders and /orders/archive accept a RequestParama to navigate on the pages, the default value is set to the first page, for the time being it does not support resizing page, which the default size is set to 12.

The Response porperty 'body' was updated to 'data' which makes more sense to acomodate the PaginatedContentResponse, where there is the content and the pagination metadata